### PR TITLE
Java. Configure RabbitMq for sharing microservice

### DIFF
--- a/share/src/main/java/io/zensoft/share/config/rabbitmq/RabbitMqComponentDeclarationConfiguration.java
+++ b/share/src/main/java/io/zensoft/share/config/rabbitmq/RabbitMqComponentDeclarationConfiguration.java
@@ -1,0 +1,66 @@
+package io.zensoft.share.config.rabbitmq;
+
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMqComponentDeclarationConfiguration {
+
+    public static final String TOPIC_SHARE = "share";
+    public static final String QUEUE_FACEBOOK_PUBLISH = "facebookPublish";
+    public static final String QUEUE_FACEBOOK_GET_INFO = "facebookGetInfo";
+    public static final String QUEUE_TELEGRAM_PUBLISH = "telegramPublish";
+    public static final String QUEUE_TELEGRAM_GET_INFO = "telegramGetInfo";
+    public static final String QUEUE_DIESEL_PUBLISH = "dieselPublish";
+    public static final String QUEUE_DIESEL_GET_INFO = "dieselGetInfo";
+    public static final String QUEUE_JOB_KG_PUBLISH = "jobKgPublish";
+    public static final String QUEUE_JOB_KG_GET_INFO = "jobKgGetInfo";
+
+    @Bean
+    public TopicExchange shareTopicExchange() {
+        return new TopicExchange(TOPIC_SHARE);
+    }
+
+    @Bean()
+    public Queue facebookPublisherQueue() {
+        return new Queue(QUEUE_FACEBOOK_PUBLISH);
+    }
+
+    @Bean
+    public Queue facebookGetInfoQueue() {
+        return new Queue(QUEUE_FACEBOOK_GET_INFO);
+    }
+
+    @Bean()
+    public Queue telegramPublisherQueue() {
+        return new Queue(QUEUE_TELEGRAM_PUBLISH);
+    }
+
+    @Bean
+    public Queue telegramGetInfoQueue() {
+        return new Queue(QUEUE_TELEGRAM_GET_INFO);
+    }
+
+    @Bean()
+    public Queue dieselPublisherQueue() {
+        return new Queue(QUEUE_DIESEL_PUBLISH);
+    }
+
+    @Bean
+    public Queue dieselGetInfoQueue() {
+        return new Queue(QUEUE_DIESEL_GET_INFO);
+    }
+
+    @Bean
+    public Queue jobKgPublisherQueue() {
+        return new Queue(QUEUE_JOB_KG_PUBLISH);
+    }
+
+    @Bean
+    public Queue jobKgGetInfoQueue() {
+        return new Queue(QUEUE_JOB_KG_GET_INFO);
+    }
+
+}

--- a/share/src/main/java/io/zensoft/share/config/rabbitmq/RabbitMqConnectionConfiguration.java
+++ b/share/src/main/java/io/zensoft/share/config/rabbitmq/RabbitMqConnectionConfiguration.java
@@ -1,0 +1,41 @@
+package io.zensoft.share.config.rabbitmq;
+
+import org.springframework.amqp.core.AmqpAdmin;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Created by temirlan on 6/27/18.
+ */
+@Configuration
+@ComponentScan
+public class RabbitMqConnectionConfiguration {
+
+    /*
+    * in future will be injected connection needed credentials
+    * temporary it runs in a localhost
+    */
+    @Bean
+    public ConnectionFactory rabbitMqConnectionFactory() {
+        CachingConnectionFactory connectionFactory =
+                new CachingConnectionFactory("localhost");
+        return connectionFactory;
+    }
+
+    @Bean
+    public AmqpAdmin amqpAdmin(ConnectionFactory connectionFactory) {
+        RabbitAdmin rabbitAdmin = new RabbitAdmin(connectionFactory);
+        return rabbitAdmin;
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        return rabbitTemplate;
+    }
+}

--- a/share/src/main/java/io/zensoft/share/config/rabbitmq/RabbitMqExchangeBindingConfiguration.java
+++ b/share/src/main/java/io/zensoft/share/config/rabbitmq/RabbitMqExchangeBindingConfiguration.java
@@ -1,0 +1,75 @@
+package io.zensoft.share.config.rabbitmq;
+
+import org.springframework.amqp.core.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Created by temirlan on 6/27/18.
+ */
+@Configuration
+@ComponentScan(basePackageClasses = {RabbitMqComponentDeclarationConfiguration.class})
+public class RabbitMqExchangeBindingConfiguration {
+
+    @Autowired
+    private TopicExchange shareTopicExchange;
+
+    private final String publish = "publish";
+    private final String getInfo = "getInfo";
+
+
+    public Binding bindQueueToTopicWith(Queue queue, TopicExchange exchange, String with) {
+        return BindingBuilder.bind(queue).to(exchange).with(with);
+    }
+
+    @Bean
+    @Autowired
+    public Binding facebookPublishBinding(Queue facebookPublisherQueue) {
+        return bindQueueToTopicWith(facebookPublisherQueue, shareTopicExchange, "facebook." + publish);
+    }
+
+    @Bean
+    @Autowired
+    public Binding facebookGetInfoBinding(Queue facebookGetInfoQueue) {
+        return bindQueueToTopicWith(facebookGetInfoQueue, shareTopicExchange, "facebook." + getInfo);
+    }
+
+    @Bean
+    @Autowired
+    public Binding telegramPublishBinding(Queue telegramPublisherQueue) {
+        return bindQueueToTopicWith(telegramPublisherQueue, shareTopicExchange, "telegram." + publish);
+    }
+
+    @Bean
+    @Autowired
+    public Binding telegramGetInfoBinding(Queue telegramGetInfoQueue) {
+        return bindQueueToTopicWith(telegramGetInfoQueue, shareTopicExchange, "telegram." + getInfo);
+    }
+
+    @Bean
+    @Autowired
+    public Binding dieselPublishBinding(Queue dieselPublisherQueue) {
+        return bindQueueToTopicWith(dieselPublisherQueue, shareTopicExchange, "diesel." + publish);
+    }
+
+    @Bean
+    @Autowired
+    public Binding dieselGetInfoBinding(Queue dieselGetInfoQueue) {
+        return bindQueueToTopicWith(dieselGetInfoQueue, shareTopicExchange, "diesel." + getInfo);
+    }
+
+    @Bean
+    @Autowired
+    public Binding jobKgPublishBinding(Queue jobKgPublisherQueue) {
+        return bindQueueToTopicWith(jobKgPublisherQueue, shareTopicExchange, "jobKg." + publish);
+    }
+
+    @Bean
+    @Autowired
+    public Binding jobKgGetInfoBinding(Queue jobKgGetInfoQueue) {
+        return bindQueueToTopicWith(jobKgGetInfoQueue, shareTopicExchange, "jobKg." + getInfo);
+    }
+
+}


### PR DESCRIPTION
Configure RabbitMq for sharing microservice:
* queues created
* topic binding with queues configured
* temporary connects to local rabbit host