### PR TITLE
Python. Allowed hosts

### DIFF
--- a/python/config/base.py
+++ b/python/config/base.py
@@ -11,7 +11,7 @@ class Base(Configuration):
 
     DEBUG = values.BooleanValue(False)
 
-    ALLOWED_HOSTS = []
+    ALLOWED_HOSTS = ['192.168.89.96']
 
     INSTALLED_APPS = [
         'django.contrib.admin',
@@ -104,7 +104,7 @@ class Base(Configuration):
 
     LANGUAGE_CODE = 'en-us'
 
-    TIME_ZONE = 'UTC'
+    TIME_ZONE = 'Asia/Bishkek'
 
     USE_I18N = True
 


### PR DESCRIPTION
To change the time zone and add ALLOWED_HOSTS = ['192.168.89.96'] in config. Specify the port yourself. example: 192.168.89.96:3000