### PR TITLE
Java send response to monolith

### DIFF
--- a/share/src/main/java/io/zensoft/share/config/rabbitmq/RabbitMqConnectionConfiguration.java
+++ b/share/src/main/java/io/zensoft/share/config/rabbitmq/RabbitMqConnectionConfiguration.java
@@ -5,6 +5,7 @@ import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -34,8 +35,9 @@ public class RabbitMqConnectionConfiguration {
     }
 
     @Bean
-    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory, MessageConverter messageConverter) {
         RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(messageConverter);
         return rabbitTemplate;
     }
 }

--- a/share/src/main/java/io/zensoft/share/service/ResponseSenderService.java
+++ b/share/src/main/java/io/zensoft/share/service/ResponseSenderService.java
@@ -1,0 +1,10 @@
+package io.zensoft.share.service;
+
+
+/**
+ * Created by temirlan on 7/3/18.
+ */
+public interface ResponseSenderService<T> {
+
+    void respond(T t);
+}

--- a/share/src/main/java/io/zensoft/share/service/VacancyResponseSenderService.java
+++ b/share/src/main/java/io/zensoft/share/service/VacancyResponseSenderService.java
@@ -1,0 +1,28 @@
+package io.zensoft.share.service;
+
+import io.zensoft.share.dto.VacancyResponseDto;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * Created by temirlan on 7/3/18.
+ */
+@Service
+public class VacancyResponseSenderService implements ResponseSenderService<VacancyResponseDto> {
+
+    private final RabbitTemplate rabbitTemplate;
+    //real queue name or exchange has to be injected
+    private String exchangeName = "share";
+
+    @Autowired
+    public VacancyResponseSenderService(RabbitTemplate rabbitTemplate) {
+        this.rabbitTemplate = rabbitTemplate;
+    }
+
+    //real queue name or exchange has to be injected
+    @Override
+    public void respond(VacancyResponseDto vacancyResponseDto) {
+        rabbitTemplate.convertAndSend(exchangeName, "facebook.publish", vacancyResponseDto);
+    }
+}


### PR DESCRIPTION
* added message converter to rabbit template that automatically converts objects to json format when sending message
* created class VacancyResponseSenderService that has method called respond(). It is responsible to send VacancyResponseDto object to monolith
* real queue name or channel has to be configured