### PR TITLE
Java. Change dto standards

### DIFF
--- a/share/src/main/java/io/zensoft/share/dto/VacancyDto.java
+++ b/share/src/main/java/io/zensoft/share/dto/VacancyDto.java
@@ -1,5 +1,6 @@
 package io.zensoft.share.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,9 +18,10 @@ public class VacancyDto {
     private List<RequirementDto> requirements;
     private String city;
     private String address;
+    @JsonProperty("name")
     private String position;
     private int count;
-    private String workingConditions;
+    private List<String> workingConditions;
     private String experience;
     private String workingHours;
     private String employmentType;

--- a/share/src/main/java/io/zensoft/share/model/Vacancy.java
+++ b/share/src/main/java/io/zensoft/share/model/Vacancy.java
@@ -23,7 +23,10 @@ public class Vacancy {
     private String address;
     private String position;
     private int count;
-    private String workingConditions;
+    @ElementCollection
+    @CollectionTable(name = "vacancy_working_condition", joinColumns = @JoinColumn(name = "vacancy_id"))
+    @Column(name = "name")
+    private List<String> workingConditions;
     private String experience;
     private String workingHours;
     private String employmentType;


### PR DESCRIPTION
* renamed vacancy position to name(i.e it will receive "name" json attribute but our share app will use position naming)
* now we receive from python list of working conditions not a single string object
* configured jpa for working conditions