### PR TITLE
Java. Remove @Service annotation from interfaces

### DIFF
--- a/share/src/main/java/io/zensoft/share/service/PublisherManagerService.java
+++ b/share/src/main/java/io/zensoft/share/service/PublisherManagerService.java
@@ -4,7 +4,6 @@ import io.zensoft.share.dto.VacancyDto;
 import io.zensoft.share.model.PublisherServiceType;
 import org.springframework.stereotype.Service;
 
-@Service
 public interface PublisherManagerService {
 
     /**

--- a/share/src/main/java/io/zensoft/share/service/PublisherService.java
+++ b/share/src/main/java/io/zensoft/share/service/PublisherService.java
@@ -4,7 +4,6 @@ import io.zensoft.share.model.Vacancy;
 import io.zensoft.share.model.VacancyResponse;
 import org.springframework.stereotype.Service;
 
-@Service
 public interface PublisherService {
 
     /**

--- a/share/src/main/java/io/zensoft/share/service/converter/DtoConverterService.java
+++ b/share/src/main/java/io/zensoft/share/service/converter/DtoConverterService.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Service;
 /**
  * Created by temirlan on 7/3/18.
  */
-@Service
 public interface DtoConverterService<MODEL, DTO> {
     DTO toDto(MODEL model);
 

--- a/share/src/main/java/io/zensoft/share/service/model/VacancyModelService.java
+++ b/share/src/main/java/io/zensoft/share/service/model/VacancyModelService.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Service;
 /**
  * Created by temirlan on 6/29/18.
  */
-@Service
 public interface VacancyModelService extends ModelRepositoryService<Vacancy, Long> {
 
 }

--- a/share/src/main/java/io/zensoft/share/service/model/VacancyResponseModelService.java
+++ b/share/src/main/java/io/zensoft/share/service/model/VacancyResponseModelService.java
@@ -10,7 +10,6 @@ import java.util.List;
 /**
  * Created by temirlan on 6/29/18.
  */
-@Service
 public interface VacancyResponseModelService extends ModelRepositoryService<VacancyResponse, Long> {
     List<VacancyResponse> getAllByVacancy(Vacancy vacancy);
 


### PR DESCRIPTION
using @Service annotation in interfaces is useless, because beans created from implementations of this interfaces, not from interfaces