### PR TITLE
Python. Fix nginx configs

### DIFF
--- a/python/config/nginx/nginx.conf
+++ b/python/config/nginx/nginx.conf
@@ -9,6 +9,7 @@ server {
 
     location / {
         proxy_pass http://web/;
+        proxy_set_header Host $http_host;
     }
 
     location /static/ {


### PR DESCRIPTION
It was showing name of the container as a host. E.g. in pagination it was showing:
```
"next": "http://web/requirements?page=2"
```
Know it is showing:
```
"next": "http://your-host/requirements?page=2"
```